### PR TITLE
adds log output in case obtaining sts credentials failed

### DIFF
--- a/aws.py
+++ b/aws.py
@@ -420,6 +420,7 @@ AWS_SESSION_TOKEN - (optional)
             finally:
                 delattr(self, 'for_sts')
             if h['_code'] != '200':
+                log('\nFailed to assume role: {}\n'.format(self.creds['sts_role']))
                 msg = '%s %s' % (h.get('_code'), h.get('_reason'))
                 if h.get('_parsed') and 'Error' in b:
                     msg = '%s: %s: %s' % (


### PR DESCRIPTION
Adds a little bit of verbosity to ease investigation of the proble,.

Otherwise the error from the script returns nothing more than this:

> RoleException: 403 Forbidden: AccessDenied: Access denied

AWS CloudTrail will be equally unhelpful simply stating:

> "errorMessage": "Not authorized to perform sts:AssumeRole"

With neither source giving a hint which role is causing this.